### PR TITLE
Added live-demo option to run inference on connected webcam

### DIFF
--- a/utils/track/ui.py
+++ b/utils/track/ui.py
@@ -207,6 +207,10 @@ class OMNITRAX_PT_TrackingPanel(bpy.types.Panel):
         col.operator(
             "scene.detection_run", text="RESTART Tracking"
         ).restart_tracking = True
+        col.label(text="Experimental Features")
+        col.operator(
+            "scene.detection_run", text="Run Webcam DEMO"
+        ).run_webcam_demo = True
 
 
 class EXPORT_PT_ManualTrackingPanel(bpy.types.Panel):


### PR DESCRIPTION
Here, I added the option to run inference on the video stream of a connected webcam, rather than on a loaded video.

This is for demo purposes only as this workflow may lead to dropped frames and currently does NOT record the source video to the computer, nor are the displayed tracks made available in Blender for editing afterwards.

Once we have verified that this works as intended and made up our mind on whether we even want to expose this functionality to other users, we can decide wether to merge this pull request or leave the branch separate for those how want to use this functionality for demo purposes.